### PR TITLE
Added Global HTTP Error Handling with Toast Notifications using Problem details approach

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,8 @@ dotnet_diagnostic.ide0052.severity = error
 dotnet_diagnostic.ide0079.severity = error
 # Remove unnecessary equality operator
 dotnet_diagnostic.ide0100.severity = error
+# Disable use primary constructor
+dotnet_diagnostic.ide0290.severity = none
 
 [*.json]
 indent_size = 2

--- a/src/backend/Services/Board/Board.Api/Authorization/BoardPermissionPolicyProvider.cs
+++ b/src/backend/Services/Board/Board.Api/Authorization/BoardPermissionPolicyProvider.cs
@@ -10,7 +10,7 @@ namespace Board.Api.Authorization;
 public sealed class BoardPermissionPolicyProvider : IAuthorizationPolicyProvider
 {
 	private readonly DefaultAuthorizationPolicyProvider _fallbackPolicyProvider;
-	private static readonly Regex PolicyRegex = new Regex(
+	private static readonly Regex PolicyRegex = new(
 		$"^{Auth.Claims.Permissions}:(?<perm>[^:]+):(?<ctx>[^:]+):(?<route>[^:]+)$",
 		RegexOptions.Compiled | RegexOptions.IgnoreCase);
 

--- a/src/backend/Services/Board/Board.Api/Configuration/GlobalExceptionHandler.cs
+++ b/src/backend/Services/Board/Board.Api/Configuration/GlobalExceptionHandler.cs
@@ -1,0 +1,123 @@
+using System.Diagnostics;
+using FluentValidation;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Board.Domain.Options;
+
+namespace Board.Api.Configuration;
+
+public sealed class GlobalExceptionHandler : IExceptionHandler
+{
+	private readonly IProblemDetailsService _problemDetailsService;
+
+	public GlobalExceptionHandler(IProblemDetailsService problemDetailsService)
+	{
+		_problemDetailsService = problemDetailsService;
+	}
+
+	public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+	{
+		(int statusCode, ProblemDetails problem) = CreateProblemDetails(httpContext, exception);
+
+		httpContext.Response.StatusCode = statusCode;
+		httpContext.Response.ContentType = "application/problem+json";
+		await _problemDetailsService.WriteAsync(new ProblemDetailsContext
+		{
+			HttpContext = httpContext,
+			ProblemDetails = problem
+		});
+		return true;
+	}
+
+	private static (int statusCode, ProblemDetails problem) CreateProblemDetails(HttpContext httpContext, Exception exception)
+	{
+		ProblemDetails problemDetails;
+		int statusCode;
+
+		// FluentValidation exceptions (from FastEndpoints validators) are wrapped differently; handle typical cases
+		if (exception is ValidationException validationException)
+		{
+			statusCode = StatusCodes.Status400BadRequest;
+			var errors = validationException.Errors
+				.GroupBy(e => e.PropertyName)
+				.ToDictionary(g => g.Key, g => g.Select(e => e.ErrorMessage).ToArray());
+
+			problemDetails = new ValidationProblemDetails(errors)
+			{
+				Title = "Validation failed",
+				Detail = "One or more validation errors occurred.",
+				Status = statusCode,
+				Type = "https://datatracker.ietf.org/doc/html/rfc7807#section-3.1",
+				Instance = httpContext.Request.Path
+			};
+		}
+		else if (exception is ForbiddenAccessException forbidden)
+		{
+			statusCode = StatusCodes.Status403Forbidden;
+			problemDetails = new ProblemDetails
+			{
+				Title = "Access denied",
+				Detail = string.IsNullOrWhiteSpace(forbidden.Message) ? "You do not have permission to perform this action." : forbidden.Message,
+				Status = statusCode,
+				Type = "https://httpstatuses.io/403",
+				Instance = httpContext.Request.Path
+			};
+		}
+		else if (exception is UnauthorizedAccessException unauthorized)
+		{
+			statusCode = StatusCodes.Status401Unauthorized;
+			problemDetails = new ProblemDetails
+			{
+				Title = "Unauthorized",
+				Detail = string.IsNullOrWhiteSpace(unauthorized.Message) ? "Authentication is required to access this resource." : unauthorized.Message,
+				Status = statusCode,
+				Type = "https://httpstatuses.io/401",
+				Instance = httpContext.Request.Path
+			};
+		}
+		else if (exception is NotImplementedException notImplemented)
+		{
+			statusCode = StatusCodes.Status501NotImplemented;
+			problemDetails = new ProblemDetails
+			{
+				Title = "Not Implemented",
+				Detail = string.IsNullOrWhiteSpace(notImplemented.Message) ? "This functionality is not implemented." : notImplemented.Message,
+				Status = statusCode,
+				Type = "https://httpstatuses.io/501",
+				Instance = httpContext.Request.Path
+			};
+		}
+		else if (exception is OptionsException optionsException)
+		{
+			statusCode = StatusCodes.Status500InternalServerError;
+			problemDetails = new ProblemDetails
+			{
+				Title = "Configuration error",
+				Detail = optionsException.Message,
+				Status = statusCode,
+				Type = "https://httpstatuses.io/500",
+				Instance = httpContext.Request.Path
+			};
+		}
+		else
+		{
+			statusCode = StatusCodes.Status500InternalServerError;
+			problemDetails = new ProblemDetails
+			{
+				Title = "An unexpected error occurred",
+				Detail = "An unexpected error occurred. Please try again later.",
+				Status = statusCode,
+				Type = "about:blank",
+				Instance = httpContext.Request.Path
+			};
+		}
+
+		problemDetails.Extensions["traceId"] = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+		return (statusCode, problemDetails);
+	}
+}
+
+public sealed class ForbiddenAccessException : Exception
+{
+	public ForbiddenAccessException(string message) : base(message) { }
+} 

--- a/src/backend/Services/Board/Board.Api/Configuration/StatusCodePagesExtensions.cs
+++ b/src/backend/Services/Board/Board.Api/Configuration/StatusCodePagesExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace Board.Api.Configuration;
+
+public static class StatusCodePagesExtensions
+{
+	public static IApplicationBuilder UseProblemDetailsForStatusCodes(this IApplicationBuilder app)
+	{
+		app.UseStatusCodePages(async context =>
+		{
+			var httpContext = context.HttpContext;
+			var response = httpContext.Response;
+
+			if (response.HasStarted)
+			{
+				return;
+			}
+
+			if (response.StatusCode == StatusCodes.Status204NoContent || response.StatusCode == StatusCodes.Status304NotModified)
+			{
+				return;
+			}
+
+			var problemDetailsService = httpContext.RequestServices.GetRequiredService<IProblemDetailsService>();
+
+			var pd = new ProblemDetails
+			{
+				Status = response.StatusCode,
+				Title = ReasonPhrases.GetReasonPhrase(response.StatusCode),
+				Type = "about:blank",
+				Instance = httpContext.Request.Path
+			};
+
+			response.ContentType = "application/problem+json";
+			await problemDetailsService.WriteAsync(new ProblemDetailsContext
+			{
+				HttpContext = httpContext,
+				ProblemDetails = pd
+			});
+		});
+
+		return app;
+	}
+} 

--- a/src/backend/Services/Board/Board.Api/Features/Board/CreateBoard/CreateBoardEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/Board/CreateBoard/CreateBoardEndpoint.cs
@@ -4,6 +4,7 @@ using Board.Application.DTOs;
 using Board.Domain.Contracts.Enums;
 using FastEndpoints;
 using IMapper = AutoMapper.IMapper;
+using Board.Api.Configuration;
 
 namespace Board.Api.Features.Board.CreateBoard;
 
@@ -38,8 +39,7 @@ public class CreateBoardEndpoint : Endpoint<CreateBoardRequest>
         {
             if (!_currentUserProvider.IsGlobalAdmin())
             {
-                //TODO add problem details
-                throw new Exception("You can not create board for other users");
+                throw new ForbiddenAccessException("You can not create board for other users");
             }
         }
 

--- a/src/backend/Services/Board/Board.Api/Features/Board/CreateBoard/CreateBoardValidator.cs
+++ b/src/backend/Services/Board/Board.Api/Features/Board/CreateBoard/CreateBoardValidator.cs
@@ -14,15 +14,22 @@ public class CreateBoardValidator : Validator<CreateBoardRequest>
         //    .MaximumLength(20).WithMessage(x => localizer["MaxLengthExceeded", x.Title, 20]);
 
         RuleFor(i => i.Title)
+            .Cascade(CascadeMode.Continue)
             .NotNull().NotEmpty().WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Title)))
             .MaximumLength(200).WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Title), 200));
 
-        RuleFor(i => i.Description).MaximumLength(100000)
+        RuleFor(i => i.Description)
+            .Cascade(CascadeMode.Continue)
+            .MaximumLength(100000)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Description), 100000));
 
-        RuleForEach(i => i.BoardUsers).NotNull().NotEmpty().SetValidator(new BoardUserValidator());
+        RuleForEach(i => i.BoardUsers)
+            .Cascade(CascadeMode.Continue)
+            .NotNull().NotEmpty().SetValidator(new BoardUserValidator());
         //TODO ADD CHECK FOR OWNER
-        RuleForEach(i => i.BoardColumns).NotNull().NotEmpty().SetValidator(new BoardColumnValidator());
+        RuleForEach(i => i.BoardColumns)
+            .Cascade(CascadeMode.Continue)
+            .NotNull().NotEmpty().SetValidator(new BoardColumnValidator());
     }
 }
 
@@ -30,9 +37,13 @@ public class BoardUserValidator : AbstractValidator<BoardUserDto>
 {
     public BoardUserValidator()
     {
-        RuleFor(c => c.Role).NotNull().NotEmpty()
+        RuleFor(c => c.Role)
+            .Cascade(CascadeMode.Continue)
+            .NotNull().NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Role)));
-        RuleFor(c => c.Email).NotNull().NotEmpty().MaximumLength(100)
+        RuleFor(c => c.Email)
+            .Cascade(CascadeMode.Continue)
+            .NotNull().NotEmpty().MaximumLength(100)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Email), 100));
     }
 }
@@ -41,10 +52,14 @@ public class BoardColumnValidator : AbstractValidator<BoardColumnDto>
 {
     public BoardColumnValidator()
     {
-        RuleFor(c => c.Title).NotNull().NotEmpty()
+        RuleFor(c => c.Title)
+            .Cascade(CascadeMode.Continue)
+            .NotNull().NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Title)))
             .MaximumLength(200).WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Title), 200));
-        RuleFor(c => c.Description).NotNull().NotEmpty().WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Description)))
+        RuleFor(c => c.Description)
+            .Cascade(CascadeMode.Continue)
+            .NotNull().NotEmpty().WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Description)))
             .MaximumLength(10000).WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Description), 10000));
     }
 }

--- a/src/backend/Services/Board/Board.Api/Features/Board/DeleteBoard/DeleteBoardEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/Board/DeleteBoard/DeleteBoardEndpoint.cs
@@ -8,25 +8,30 @@ namespace Board.Api.Features.Board.DeleteBoard;
 
 public class DeleteBoardEndpoint : EndpointWithoutRequest
 {
-    public override void Configure()
-    {
-        Delete("/api/boards/{boardId}");
-        Policies(Auth.BuildPermissionPolicy(Permission.ManageBoard, Context.BoardColumn, "boardId"));
-    }
+	public override void Configure()
+	{
+		Delete("/api/boards/{boardId}");
+		Policies(Auth.BuildPermissionPolicy(Permission.ManageBoard, Context.BoardColumn, "boardId"));
+	}
 
-    private readonly IBoardRepository _repository;
-    public DeleteBoardEndpoint(IBoardRepository repository)
-    {
-        _repository = repository;
-    }
+	private readonly IBoardRepository _repository;
+	public DeleteBoardEndpoint(IBoardRepository repository)
+	{
+		_repository = repository;
+	}
 
-    public override async Task HandleAsync(CancellationToken cancellationToken)
-    {
-        Guid id = Route<Guid>("boardId");
+	public override async Task HandleAsync(CancellationToken cancellationToken)
+	{
+		Guid id = Route<Guid>("boardId");
 
-        Domain.Entities.Board entity = await _repository.GetAsync(x => x.Id == id, cancellationToken);
-        await _repository.DeleteAsync(entity, cancellationToken);
+		Domain.Entities.Board entity = await _repository.GetAsync(x => x.Id == id, cancellationToken);
+		if (entity == null)
+		{
+			await Send.NotFoundAsync(cancellationToken);
+			return;
+		}
+		await _repository.DeleteAsync(entity, cancellationToken);
 
-        await Send.OkAsync(true, cancellationToken);
-    }
+		await Send.NoContentAsync(cancellationToken);
+	}
 }

--- a/src/backend/Services/Board/Board.Api/Features/Board/GetBoardById/GetBoardByIdEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/Board/GetBoardById/GetBoardByIdEndpoint.cs
@@ -32,7 +32,8 @@ public class GetBoardByIdEndpoint : EndpointWithoutRequest
         Domain.Entities.Board entity = await _repository.GetAsync(x => x.Id == id, cancellationToken, true, x => x.BoardColumns, x => x.BoardUsers, x => x.BoardTemplate);
         if (entity == null)
         {
-            await Send.OkAsync(null, cancellationToken);
+            			await Send.NotFoundAsync(cancellationToken);
+			return;
         }
 
         BoardDto response = _mapper.Map<BoardDto>(entity);

--- a/src/backend/Services/Board/Board.Api/Features/Board/UpdateBoard/UpdateBoardEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/Board/UpdateBoard/UpdateBoardEndpoint.cs
@@ -32,7 +32,8 @@ public class UpdateBoardEndpoint : Endpoint<UpdateBoardRequest>
         Domain.Entities.Board entity = await _repository.GetAsync(x => x.Id == id, cancellationToken, false, x => x.BoardColumns, x => x.BoardUsers);
         if (entity == null)
         {
-            await Send.OkAsync(null, cancellationToken);
+            HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
         }
 
         entity.Title = request.Title;

--- a/src/backend/Services/Board/Board.Api/Features/BoardColumn/CreateBoardColumn/CreateBoardColumnEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardColumn/CreateBoardColumn/CreateBoardColumnEndpoint.cs
@@ -27,13 +27,9 @@ public class CreateBoardColumnEndpoint : Endpoint<CreateBoardItemRequest>
     {
         Guid boardId = Route<Guid>("boardId");
 
-        Domain.Entities.Board board = await _boardRepository.GetAsync(b => b.Id == boardId, cancellationToken, true, b => b.BoardColumns);
-        if (board == null)
-        {
-            throw new InvalidOperationException("Board not found");
-        }
-
-        Domain.Entities.BoardColumn entity = new Domain.Entities.BoardColumn
+        Domain.Entities.Board board = await _boardRepository.GetAsync(b => b.Id == boardId, cancellationToken, true, b => b.BoardColumns)
+            ?? throw new InvalidOperationException("Board not found");
+        Domain.Entities.BoardColumn entity = new()
         {
             Id = Guid.NewGuid(),
             Title = request.Title,
@@ -44,7 +40,7 @@ public class CreateBoardColumnEndpoint : Endpoint<CreateBoardItemRequest>
         await _columnRepository.AddAsync(entity, cancellationToken);
         await _boardRepository.UpdateAsync(board, cancellationToken);
 
-        BoardColumnDto response = new BoardColumnDto
+        BoardColumnDto response = new()
         {
             Id = entity.Id,
             Title = entity.Title,

--- a/src/backend/Services/Board/Board.Api/Features/BoardColumn/CreateBoardColumn/CreateBoardColumnValidator.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardColumn/CreateBoardColumn/CreateBoardColumnValidator.cs
@@ -9,11 +9,13 @@ public class CreateBoardColumnValidator : Validator<CreateBoardItemRequest>
     public CreateBoardColumnValidator()
     {
         RuleFor(x => x.Title)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Title)))
             .MaximumLength(200)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Title), 200));
         RuleFor(x => x.Description)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Description)))
             .MaximumLength(10000)

--- a/src/backend/Services/Board/Board.Api/Features/BoardColumn/DeleteBoardColumn/DeleteBoardColumnEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardColumn/DeleteBoardColumn/DeleteBoardColumnEndpoint.cs
@@ -8,29 +8,30 @@ namespace Board.Api.Features.BoardColumn.DeleteBoardColumn;
 
 public class DeleteBoardColumnEndpoint : EndpointWithoutRequest
 {
-    private readonly IBoardColumnRepository _repository;
+	private readonly IBoardColumnRepository _repository;
 
-    public DeleteBoardColumnEndpoint(IBoardColumnRepository repository)
-    {
-        _repository = repository;
-    }
-    public override void Configure()
-    {
-        Delete("/api/boards/{boardId}/columns/{id}");
-        Policies(Auth.BuildPermissionPolicy(Permission.ManageBoard, Context.BoardColumn, "boardId"));
-    }
+	public DeleteBoardColumnEndpoint(IBoardColumnRepository repository)
+	{
+		_repository = repository;
+	}
+	public override void Configure()
+	{
+		Delete("/api/boards/{boardId}/columns/{id}");
+		Policies(Auth.BuildPermissionPolicy(Permission.ManageBoard, Context.BoardColumn, "boardId"));
+	}
 
-    public override async Task HandleAsync(CancellationToken cancellationToken)
-    {
-        Guid id = Route<Guid>("id");
-        Domain.Entities.BoardColumn entity = await _repository.GetAsync(x => x.Id == id, cancellationToken, false);
-        if (entity == null)
-        {
-            await Send.OkAsync(false, cancellationToken);
-        }
+	public override async Task HandleAsync(CancellationToken cancellationToken)
+	{
+		Guid id = Route<Guid>("id");
+		Domain.Entities.BoardColumn entity = await _repository.GetAsync(x => x.Id == id, cancellationToken, false);
+		if (entity == null)
+		{
+			await Send.NotFoundAsync(cancellationToken);
+			return;
+		}
 
-        await _repository.DeleteAsync(entity, cancellationToken);
-        await Send.OkAsync(true, cancellationToken);
+		await _repository.DeleteAsync(entity, cancellationToken);
+		await Send.NoContentAsync(cancellationToken);
 
-    }
+	}
 }

--- a/src/backend/Services/Board/Board.Api/Features/BoardColumn/GetBoardColumnById/GetBoardColumnByIdEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardColumn/GetBoardColumnById/GetBoardColumnByIdEndpoint.cs
@@ -11,29 +11,33 @@ namespace Board.Api.Features.BoardColumn.GetBoardColumnById;
 public class GetBoardColumnByIdEndpoint : EndpointWithoutRequest
 {
 
-    private readonly IBoardColumnRepository _repository;
-    private readonly IMapper _mapper;
+	private readonly IBoardColumnRepository _repository;
+	private readonly IMapper _mapper;
 
-    public GetBoardColumnByIdEndpoint(IBoardColumnRepository repository, IMapper mapper)
-    {
-        _repository = repository;
-        _mapper = mapper;
-    }
-    public override void Configure()
-    {
-        Get("/api/boards/{boardId}/columns/{id}");
-        Policies(Auth.BuildPermissionPolicy(Permission.Read, Context.BoardColumn, "boardId"));
-    }
+	public GetBoardColumnByIdEndpoint(IBoardColumnRepository repository, IMapper mapper)
+	{
+		_repository = repository;
+		_mapper = mapper;
+	}
+	public override void Configure()
+	{
+		Get("/api/boards/{boardId}/columns/{id}");
+		Policies(Auth.BuildPermissionPolicy(Permission.Read, Context.BoardColumn, "boardId"));
+	}
 
-    public override async Task HandleAsync(CancellationToken cancellationToken)
-    {
-        Guid id = Route<Guid>("id");
+	public override async Task HandleAsync(CancellationToken cancellationToken)
+	{
+		Guid id = Route<Guid>("id");
 
-        Domain.Entities.BoardColumn entity = await _repository.GetAsync(x => x.Id == id, cancellationToken);
-        BoardColumnDto response = entity == null
-            ? null
-            : _mapper.Map<BoardColumnDto>(entity);
+		Domain.Entities.BoardColumn entity = await _repository.GetAsync(x => x.Id == id, cancellationToken);
+		if (entity == null)
+		{
+            await Send.NotFoundAsync(cancellationToken);
+			return;
+		}
 
-        await Send.OkAsync(response, cancellationToken);
-    }
+		BoardColumnDto response = _mapper.Map<BoardColumnDto>(entity);
+
+		await Send.OkAsync(response, cancellationToken);
+	}
 }

--- a/src/backend/Services/Board/Board.Api/Features/BoardColumn/UpdateBoardColumn/UpdateBoardColumnEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardColumn/UpdateBoardColumn/UpdateBoardColumnEndpoint.cs
@@ -27,12 +27,8 @@ public class UpdateBoardColumnEndpoint : Endpoint<UpdateBoardColumnRequest>
 
     public override async Task HandleAsync(UpdateBoardColumnRequest request, CancellationToken cancellationToken)
     {
-        Domain.Entities.BoardColumn entity = await _repository.GetAsync(x => x.Id == request.Id, cancellationToken, false);
-        if (entity == null)
-        {
-            throw new InvalidOperationException("Column not found");
-        }
-
+        Domain.Entities.BoardColumn entity = await _repository.GetAsync(x => x.Id == request.Id, cancellationToken, false)
+            ?? throw new InvalidOperationException("Column not found");
         entity.Title = request.Title;
         entity.Description = request.Description;
 

--- a/src/backend/Services/Board/Board.Api/Features/BoardColumn/UpdateBoardColumn/UpdateBoardColumnValidator.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardColumn/UpdateBoardColumn/UpdateBoardColumnValidator.cs
@@ -9,14 +9,17 @@ public class UpdateBoardColumnValidator : Validator<UpdateBoardColumnRequest>
     public UpdateBoardColumnValidator()
     {
         RuleFor(x => x.Id)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Id)));
         RuleFor(x => x.Title)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Title)))
             .MaximumLength(200)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Title), 200));
         RuleFor(x => x.Description)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Description)))
             .MaximumLength(10000)

--- a/src/backend/Services/Board/Board.Api/Features/BoardItems/CreateBoardItem/CreateBoardItemEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardItems/CreateBoardItem/CreateBoardItemEndpoint.cs
@@ -27,7 +27,7 @@ public class CreateBoardItemEndpoint : Endpoint<CreateBoardItemRequest>
 
     public override async Task HandleAsync(CreateBoardItemRequest request, CancellationToken cancellationToken)
     {
-        BoardItem entity = new BoardItem
+        BoardItem entity = new()
         {
             Id = Guid.NewGuid(),
             Title = request.Title,

--- a/src/backend/Services/Board/Board.Api/Features/BoardItems/CreateBoardItem/CreateBoardItemValidator.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardItems/CreateBoardItem/CreateBoardItemValidator.cs
@@ -9,18 +9,23 @@ public class CreateBoardItemValidator : Validator<CreateBoardItemRequest>
     public CreateBoardItemValidator()
     {
         RuleFor(i => i.Title)
+            .Cascade(CascadeMode.Continue)
             .NotNull().NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Title)))
             .MaximumLength(500)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Title), 500));
         RuleFor(i => i.Description)
+            .Cascade(CascadeMode.Continue)
             .MaximumLength(1000000)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Description), 1000000));
         RuleFor(i => i.Priority)
+            .Cascade(CascadeMode.Continue)
             .IsInEnum();
         RuleFor(i => i.TaskType)
+            .Cascade(CascadeMode.Continue)
             .IsInEnum();
         RuleFor(i => i.BoardColumnId)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.BoardColumnId)));
     }

--- a/src/backend/Services/Board/Board.Api/Features/BoardItems/DeleteBoardItem/DeleteBoardItemEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardItems/DeleteBoardItem/DeleteBoardItemEndpoint.cs
@@ -9,31 +9,32 @@ namespace Board.Api.Features.BoardItems.DeleteBoardItem;
 
 public class DeleteBoardItemEndpoint : EndpointWithoutRequest
 {
-    private readonly IBoardItemRepository _repository;
+	private readonly IBoardItemRepository _repository;
 
-    public DeleteBoardItemEndpoint(IBoardItemRepository repository)
-    {
-        _repository = repository;
-    }
-    public override void Configure()
-    {
-        Delete("/api/boards/{boardId}/items/{Id}");
-        Policies(Auth.BuildPermissionPolicy(Permission.ManageItems, Context.BoardItem, "boardId"));
-    }
+	public DeleteBoardItemEndpoint(IBoardItemRepository repository)
+	{
+		_repository = repository;
+	}
+	public override void Configure()
+	{
+		Delete("/api/boards/{boardId}/items/{Id}");
+		Policies(Auth.BuildPermissionPolicy(Permission.ManageItems, Context.BoardItem, "boardId"));
+	}
 
-    public override async Task HandleAsync(CancellationToken cancellationToken)
-    {
-        Guid id = Route<Guid>("id");
+	public override async Task HandleAsync(CancellationToken cancellationToken)
+	{
+		Guid id = Route<Guid>("id");
 
-        BoardItem entity = await _repository.GetAsync(x => x.Id == id, cancellationToken);
-        if (entity == null)
-        {
-            await Send.OkAsync(false, cancellationToken);
-        }
+		BoardItem entity = await _repository.GetAsync(x => x.Id == id, cancellationToken);
+		if (entity == null)
+		{
+			await Send.NotFoundAsync(cancellationToken);
+			return;
+		}
 
-        await _repository.DeleteAsync(entity, cancellationToken);
-        await Send.OkAsync(true, cancellationToken);
-    }
+		await _repository.DeleteAsync(entity, cancellationToken);
+		await Send.NoContentAsync(cancellationToken);
+	}
 }
 
 

--- a/src/backend/Services/Board/Board.Api/Features/BoardItems/GetBoardItemById/GetBoardItemByIdEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardItems/GetBoardItemById/GetBoardItemByIdEndpoint.cs
@@ -32,7 +32,8 @@ public class GetBoardItemByIdEndpoint : EndpointWithoutRequest
         BoardItem entity = await _repository.GetAsync(x => x.Id == id, cancellationToken);
         if (entity == null)
         {
-            await Send.OkAsync(null, cancellationToken);
+            			await Send.NotFoundAsync(cancellationToken);
+			return;
         }
 
         BoardItemDto response = _mapper.Map<BoardItemDto>(entity);

--- a/src/backend/Services/Board/Board.Api/Features/BoardItems/UpdateBoardItem/UpdateBoardItemEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardItems/UpdateBoardItem/UpdateBoardItemEndpoint.cs
@@ -32,7 +32,8 @@ public class UpdateBoardItemEndpoint : Endpoint<UpdateBoardItemRequest>
         BoardItem entity = await _repository.GetAsync(x => x.Id == id, cancellationToken);
         if (entity == null)
         {
-            await Send.OkAsync(null, cancellationToken);
+            			await Send.NotFoundAsync(cancellationToken);
+			return;
         }
 
         entity.Title = request.Title;

--- a/src/backend/Services/Board/Board.Api/Features/BoardItems/UpdateBoardItem/UpdateBoardItemValidator.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardItems/UpdateBoardItem/UpdateBoardItemValidator.cs
@@ -9,18 +9,23 @@ public class UpdateBoardItemValidator : Validator<UpdateBoardItemRequest>
     public UpdateBoardItemValidator()
     {
         RuleFor(i => i.Title)
+            .Cascade(CascadeMode.Continue)
             .NotNull().NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Title)))
             .MaximumLength(500)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Title), 500));
         RuleFor(i => i.Description)
+            .Cascade(CascadeMode.Continue)
             .MaximumLength(1000000)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Description), 1000000));
         RuleFor(i => i.Priority)
+            .Cascade(CascadeMode.Continue)
             .IsInEnum();
         RuleFor(i => i.TaskType)
+            .Cascade(CascadeMode.Continue)
             .IsInEnum();
         RuleFor(i => i.BoardColumnId)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.BoardColumnId)));
     }

--- a/src/backend/Services/Board/Board.Api/Features/BoardTemplates/CreateBoardTemplate/CreateBoardTemplateEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardTemplates/CreateBoardTemplate/CreateBoardTemplateEndpoint.cs
@@ -20,7 +20,7 @@ public class CreateBoardTemplateEndpoint : Endpoint<CreateBoardTemplateRequest>
 
     public override async Task HandleAsync(CreateBoardTemplateRequest request, CancellationToken ct)
     {
-        BoardTemplate entity = new BoardTemplate
+        BoardTemplate entity = new()
         {
             Title = request.Title,
             Description = request.Description,
@@ -29,7 +29,7 @@ public class CreateBoardTemplateEndpoint : Endpoint<CreateBoardTemplateRequest>
         };
 
         BoardTemplate created = await _repository.AddAsync(entity, ct);
-        BoardTemplateDto response = new BoardTemplateDto
+        BoardTemplateDto response = new()
         {
             Title = created.Title,
             Description = created.Description,

--- a/src/backend/Services/Board/Board.Api/Features/BoardTemplates/CreateBoardTemplate/CreateBoardTemplateValidator.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardTemplates/CreateBoardTemplate/CreateBoardTemplateValidator.cs
@@ -9,16 +9,19 @@ public class CreateBoardTemplateValidator : Validator<CreateBoardTemplateRequest
     public CreateBoardTemplateValidator()
     {
         RuleFor(x => x.Title)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Title)))
             .MaximumLength(200)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Title), 200));
         RuleFor(x => x.Description)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.Description)))
             .MaximumLength(10000)
             .WithMessage(x => string.Format(SharedResources.MaxLengthExceeded, nameof(x.Description), 10000));
         RuleFor(x => x.BoardId)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.BoardId)));
     }

--- a/src/backend/Services/Board/Board.Api/Features/BoardTemplates/GetBoardTemplateById/GetBoardTemplateByIdEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardTemplates/GetBoardTemplateById/GetBoardTemplateByIdEndpoint.cs
@@ -22,14 +22,17 @@ public class GetBoardTemplateByIdEndpoint : EndpointWithoutRequest
     {
         Guid id = Route<Guid>("id");
         BoardTemplate entity = await _repository.GetAsync(x => x.Id == id, ct);
-        BoardTemplateDto response = entity == null
-            ? null
-            : new BoardTemplateDto
-            {
-                Title = entity.Title,
-                Description = entity.Description,
-                BoardId = entity.Id
-            };
+        if (entity == null)
+        {
+            			await Send.NotFoundAsync(ct);
+			return;
+        }
+        BoardTemplateDto response = new BoardTemplateDto
+        {
+            Title = entity.Title,
+            Description = entity.Description,
+            BoardId = entity.Id
+        };
 
         await Send.OkAsync(response, ct);
     }

--- a/src/backend/Services/Board/Board.Api/Features/BoardTemplates/SearchBoardTemplates/SearchBoardTemplateValidator.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardTemplates/SearchBoardTemplates/SearchBoardTemplateValidator.cs
@@ -9,6 +9,7 @@ public class SearchBoardTemplateValidator : Validator<SearchBoardTemplatesReques
     public SearchBoardTemplateValidator()
     {
         RuleFor(x => x.SearchTerm)
+            .Cascade(CascadeMode.Continue)
             .NotEmpty()
             .WithMessage(x => string.Format(SharedResources.FieldIsRequired, nameof(x.SearchTerm)))
             .MinimumLength(3);

--- a/src/backend/Services/Board/Board.Api/Features/BoardTemplates/UpdateBoardTemplate/UpdateBoardTemplateEndpoint.cs
+++ b/src/backend/Services/Board/Board.Api/Features/BoardTemplates/UpdateBoardTemplate/UpdateBoardTemplateEndpoint.cs
@@ -32,7 +32,7 @@ public class UpdateBoardTemplateEndpoint : Endpoint<UpdateBoardTemplateRequest>
         entity.Id = request.BoardId;
 
         BoardTemplate updated = await _repository.UpdateAsync(entity, ct);
-        BoardTemplateDto response = new BoardTemplateDto
+        BoardTemplateDto response = new()
         {
             Title = updated.Title,
             Description = updated.Description,

--- a/src/backend/Services/Board/Board.Api/Program.cs
+++ b/src/backend/Services/Board/Board.Api/Program.cs
@@ -48,6 +48,10 @@ services.ConfigureAuth(authOptions)
     .AddInfrastructure(configuration)
     .ConfigureApplication();
 
+// ProblemDetails + Exception handling
+services.AddProblemDetails();
+services.AddExceptionHandler<GlobalExceptionHandler>();
+
 services.AddSingleton<IAuthorizationPolicyProvider, BoardPermissionPolicyProvider>();
 services.AddScoped<IAuthorizationHandler, BoardPermissionHandler>();
 
@@ -73,11 +77,23 @@ if (!app.Environment.IsDevelopment())
     app.UseHttpsRedirection();
 }
 
+// Enable centralized exception handling with ProblemDetails
+app.UseExceptionHandler();
+
+// ProblemDetails for non-exception status codes
+app.UseProblemDetailsForStatusCodes();
+
 app.UseCors(AllowAllCorsPolicy);
 app.UseAuthentication();
 
 app.UseAuthorization();
-app.UseFastEndpoints();
+
+// Configure FastEndpoints to emit RFC7807 and return all validation failures
+app.UseFastEndpoints(cfg =>
+{
+    cfg.Errors.UseProblemDetails();
+});
+
 app.MapControllers();
 
 app.Run();

--- a/src/backend/Services/Board/Board.Application/Services/CurrentUserProvider.cs
+++ b/src/backend/Services/Board/Board.Application/Services/CurrentUserProvider.cs
@@ -7,12 +7,12 @@ namespace Board.Application.Services;
 public class CurrentUserProvider : ICurrentUserProvider
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
-    private ClaimsPrincipal? User => _httpContextAccessor.HttpContext?.User;
+    private ClaimsPrincipal User => _httpContextAccessor.HttpContext?.User;
     public CurrentUserProvider(IHttpContextAccessor httpContextAccessor)
     {
         _httpContextAccessor = httpContextAccessor;
     }
-    public string? GetUserEmail()
+    public string GetUserEmail()
     {
         return User?.FindFirst(ClaimTypes.Email)?.Value;
     }

--- a/src/backend/Services/Board/Board.Infrastructure/Data/Repositories/Repository.cs
+++ b/src/backend/Services/Board/Board.Infrastructure/Data/Repositories/Repository.cs
@@ -49,7 +49,7 @@ public abstract class Repository<T> : IRepository<T>
     {
         if (string.IsNullOrWhiteSpace(searchTerm))
         {
-            return new List<T>();
+            return [];
         }
 
         Expression<Func<T, bool>> predicate = x => false;
@@ -127,7 +127,7 @@ public abstract class Repository<T> : IRepository<T>
                            .ToListAsync(cancellationToken);
     }
 
-    private static Expression<Func<T, bool>> OrElse<T>(
+    private static Expression<Func<T, bool>> OrElse(
         Expression<Func<T, bool>> expr1,
         Expression<Func<T, bool>> expr2)
     {

--- a/src/frontend/Board.Web/angular.json
+++ b/src/frontend/Board.Web/angular.json
@@ -47,13 +47,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "2mb",
+                  "maximumError": "3mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "32kb",
+                  "maximumError": "64kb"
                 }
               ],
               "outputHashing": "all",

--- a/src/frontend/Board.Web/src/app/app.config.ts
+++ b/src/frontend/Board.Web/src/app/app.config.ts
@@ -27,10 +27,11 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateService } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { UnauthorizedInterceptor } from './core/Interceptors/unathorized.interceptor';
-import { HttpLoaderInterceptor } from './core/Interceptors/http-loader.interceptor';
-import { LanguageInterceptor } from './core/Interceptors/language.interceptor';
-import { HttpNotificationInterceptorService } from './core/Interceptors/http-notification-interceptor-service';
+import { UnauthorizedInterceptor } from './core/interceptors/unathorized.interceptor';
+import { HttpLoaderInterceptor } from './core/interceptors/http-loader.interceptor';
+import { LanguageInterceptor } from './core/interceptors/language.interceptor';
+import { HttpNotificationInterceptorService } from './core/interceptors/http-notification-interceptor-service';
+import { ErrorHandlingInterceptor } from './core/interceptors/error-handling.interceptor';
 
 // translations are stored in assets/i18n/*.json
 
@@ -145,6 +146,11 @@ export const appConfig: ApplicationConfig = {
       provide: HTTP_INTERCEPTORS,
       useClass: HttpNotificationInterceptorService,
       multi: true, // this ensures you can have multiple interceptors if needed
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: ErrorHandlingInterceptor,
+      multi: true,
     },
   ],
 };

--- a/src/frontend/Board.Web/src/app/core/Interceptors/http-notification-interceptor-service.ts
+++ b/src/frontend/Board.Web/src/app/core/Interceptors/http-notification-interceptor-service.ts
@@ -26,8 +26,8 @@ export class HttpNotificationInterceptorService implements HttpInterceptor {
         },
         error: (error) => {
           if (error instanceof HttpErrorResponse) {
-            this.toastr.error(this.translate.instant('NOTIFICATIONS.REQUEST_FAILED'),
-              this.translate.instant('NOTIFICATIONS.ERROR'));
+            // Delegate error toast to ErrorHandlingInterceptor; do not show here
+            // no-op
           }
         }
       })

--- a/src/frontend/Board.Web/src/app/core/interceptors/error-handling.interceptor.ts
+++ b/src/frontend/Board.Web/src/app/core/interceptors/error-handling.interceptor.ts
@@ -1,0 +1,104 @@
+import { Injectable, Injector } from '@angular/core';
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable, catchError, throwError } from 'rxjs';
+import { NotificationService } from 'src/app/core/services/other/notification.service';
+import { TranslateService } from '@ngx-translate/core';
+
+interface ProblemDetails {
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  instance?: string;
+}
+
+interface ValidationError {
+  name: string;
+  reason: string;
+}
+
+interface ValidationProblemDetails extends ProblemDetails {
+  errors?: ValidationError[];
+}
+
+@Injectable()
+export class ErrorHandlingInterceptor implements HttpInterceptor {
+  constructor(private notification: NotificationService, private injector: Injector) {}
+
+  private get translate() {
+    return this.injector.get(TranslateService);
+  }
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(req).pipe(
+      catchError((error: unknown) => {
+        if (error instanceof HttpErrorResponse) {
+          const body: unknown = error.error;
+          
+          // Case 1: ValidationProblemDetails (400 + non-empty errors array)
+          if (error.status === 400 && this.isValidationProblemDetails(body) && this.hasAnyValidationErrors(body.errors)) {
+            const validationErrors = this.formatValidationErrors(body.errors!);
+            this.notification.error(
+              validationErrors,
+              this.translate.instant('ERRORS.VALIDATION_TITLE')
+            );
+            return throwError(() => error);
+          }
+          
+          // Case 2: Any other ProblemDetails
+          const title = this.extractProblemTitle(body) ?? this.translate.instant('ERRORS.UNEXPECTED_ERROR');
+          const errorTitle = this.getErrorTitle(error.status);
+          this.notification.error(title, errorTitle);
+          return throwError(() => error);
+        }
+        return throwError(() => error);
+      })
+    );
+  }
+
+  private isValidationProblemDetails(body: unknown): body is ValidationProblemDetails {
+    return !!body && typeof body === 'object' && 'errors' in (body as ValidationProblemDetails);
+  }
+
+  private hasAnyValidationErrors(errors: ValidationProblemDetails['errors']): boolean {
+    if (!errors) {
+      return false;
+    }
+    return Array.isArray(errors) && errors.length > 0;
+  }
+
+  private extractProblemTitle(body: unknown): string | undefined {
+    if (!body || typeof body === 'object') {
+      return undefined;
+    }
+    const pd = body as ProblemDetails;
+    return pd.title || pd.detail;
+  }
+
+  private getErrorTitle(status: number): string {
+    switch (status) {
+      case 401:
+        return this.translate.instant('ERRORS.UNAUTHORIZED_TITLE');
+      case 403:
+        return this.translate.instant('ERRORS.FORBIDDEN_TITLE');
+      case 404:
+        return this.translate.instant('ERRORS.NOT_FOUND_TITLE');
+      case 500:
+        return this.translate.instant('ERRORS.SERVER_ERROR_TITLE');
+      default:
+        return this.translate.instant('ERRORS.ERROR_TITLE');
+    }
+  }
+
+  private formatValidationErrors(errors: ValidationError[]): string {
+    if (!errors || errors.length === 0) {
+      return this.translate.instant('ERRORS.VALIDATION_FAILED');
+    }
+
+    const errorMessages = errors.map((error, index) => {
+      return `${index + 1}. ${error.reason}`;
+    });
+
+    return errorMessages.join('\n');
+  }
+} 

--- a/src/frontend/Board.Web/src/app/core/services/other/dialog.service.ts
+++ b/src/frontend/Board.Web/src/app/core/services/other/dialog.service.ts
@@ -3,7 +3,7 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { BoardItem, AddBoardDTO, BoardDetailsDTO, UpdateBoardDTO } from '../../models';
 import { Observable } from 'rxjs';
 import { TaskModalComponent, TaskModalData } from 'src/app/pages/boards-section/board/modals/task-modal/task-modal.component';
-import { CreateBoardModalComponent, CreateBoardModalData } from 'src/app/pages/boards-section/boards-list/modals/create-board-modal/create-board-modal.component';
+import { CreateBoardModalComponent, CreateBoardModalData, BoardModalResult } from 'src/app/pages/boards-section/boards-list/modals/create-board-modal/create-board-modal.component';
 
 @Injectable({
   providedIn: 'root'
@@ -27,7 +27,7 @@ export class DialogService {
     return dialogRef.afterClosed();
   }
 
-  openCreateBoardModal(): Observable<AddBoardDTO | undefined> {
+  openCreateBoardModal(): Observable<BoardModalResult | undefined> {
     const dialogRef: MatDialogRef<CreateBoardModalComponent> = this.dialog.open(CreateBoardModalComponent, {
       width: '700px',
       maxWidth: '90vw',
@@ -43,7 +43,7 @@ export class DialogService {
     return dialogRef.afterClosed();
   }
 
-  openEditBoardModal(board: BoardDetailsDTO): Observable<UpdateBoardDTO | undefined> {
+  openEditBoardModal(board: BoardDetailsDTO): Observable<BoardModalResult | undefined> {
     const dialogRef: MatDialogRef<CreateBoardModalComponent> = this.dialog.open(CreateBoardModalComponent, {
       width: '700px',
       maxWidth: '90vw',

--- a/src/frontend/Board.Web/src/app/core/services/other/notification.service.ts
+++ b/src/frontend/Board.Web/src/app/core/services/other/notification.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { ToastrService } from 'ngx-toastr';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  constructor(private toastr: ToastrService) {}
+
+  error(message: string, title?: string): void {
+    this.toastr.error(message, title);
+  }
+
+  warning(message: string, title?: string): void {
+    this.toastr.warning(message, title);
+  }
+} 

--- a/src/frontend/Board.Web/src/app/pages/boards-section/board/board.component.ts
+++ b/src/frontend/Board.Web/src/app/pages/boards-section/board/board.component.ts
@@ -12,6 +12,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { boardItemToTask, taskToCreateDto, taskToUpdateDto } from 'src/app/core/mappers/board-item.mapper';
 import { UserService } from 'src/app/core/services/auth/user.service';
+import { BoardModalResult } from 'src/app/pages/boards-section/boards-list/modals/create-board-modal/create-board-modal.component';
 
 
 @Component({
@@ -238,14 +239,13 @@ export class BoardComponent implements OnInit {
   }
 
   openSettings(): void {
-    this.dialogService.openEditBoardModal(this.currentBoard as BoardDetailsDTO).subscribe((updateDto?: UpdateBoardDTO) => {
-      if (updateDto) {
-        this.boardApiService.updateBoard(updateDto).subscribe(()=>{
-          this.boardApiService.getBoardById(this.currentBoardId as string).subscribe({
-            next: (board) => {
-              this.currentBoard = board;
-            }
-          });
+    this.dialogService.openEditBoardModal(this.currentBoard as BoardDetailsDTO).subscribe((result?: BoardModalResult) => {
+      if (result?.success && result?.boards) {
+        // Board was updated successfully, refresh current board data
+        this.boardApiService.getBoardById(this.currentBoardId as string).subscribe({
+          next: (board) => {
+            this.currentBoard = board;
+          }
         });
       }
     });

--- a/src/frontend/Board.Web/src/app/pages/boards-section/board/components/description-editor/description-editor.component.html
+++ b/src/frontend/Board.Web/src/app/pages/boards-section/board/components/description-editor/description-editor.component.html
@@ -4,9 +4,11 @@
                     class="editor-menu">
     </ngx-editor-menu>
     <div class="editor-container">
-        <ngx-editor [placeholder]="'Description...'"
+        <ngx-editor [placeholder]="placeholder"
                     [editor]="editor"
-                    [formControl]="formControl"
+                    [ngModel]="value"
+                    (ngModelChange)="onContentChange($event)"
                     class="description">
         </ngx-editor>
+    </div>
 </div>

--- a/src/frontend/Board.Web/src/app/pages/boards-section/board/components/description-editor/description-editor.component.ts
+++ b/src/frontend/Board.Web/src/app/pages/boards-section/board/components/description-editor/description-editor.component.ts
@@ -1,25 +1,26 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { FormsModule, FormGroup } from '@angular/forms';
+import { Component, Input, OnDestroy, OnInit, forwardRef } from '@angular/core';
+import { FormsModule, ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Editor, NgxEditorComponent, NgxEditorMenuComponent, Toolbar } from 'ngx-editor';
-import { ReactiveFormsModule, FormControl } from '@angular/forms';
 
 @Component({
   selector: 'app-description-editor',
   imports: [
     NgxEditorComponent,
     NgxEditorMenuComponent,
-    FormsModule,
-    ReactiveFormsModule
-],
+    FormsModule
+  ],
   templateUrl: './description-editor.component.html',
   styleUrl: './description-editor.component.scss',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => DescriptionEditorComponent),
+      multi: true
+    }
+  ]
 })
-export class DescriptionEditorComponent implements
-  OnInit,
-  OnDestroy
-{
+export class DescriptionEditorComponent implements OnInit, OnDestroy, ControlValueAccessor {
   @Input() placeholder: string = '';
-  @Input() formControl!: FormControl;
 
   editor: Editor = new Editor();
   toolbar: Toolbar = [
@@ -34,13 +35,40 @@ export class DescriptionEditorComponent implements
     ['undo', 'redo'],
   ];
 
+  private onChange = (value: any) => {};
+  private onTouched = () => {};
+  public value = '';
+
   ngOnInit(): void {
-    if (this.formControl) {
-      this.editor.setContent(this.formControl.value || '');
-    }
+    this.editor.setContent(this.value);
   }
 
   ngOnDestroy(): void {
     this.editor?.destroy();
+  }
+
+  writeValue(value: any): void {
+    this.value = value || '';
+    if (this.editor) {
+      this.editor.setContent(this.value);
+    }
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    // Implement if needed
+  }
+
+  onContentChange(value: string): void {
+    this.value = value;
+    this.onChange(value);
+    this.onTouched();
   }
 }

--- a/src/frontend/Board.Web/src/app/pages/boards-section/board/modals/task-modal/task-modal.component.ts
+++ b/src/frontend/Board.Web/src/app/pages/boards-section/board/modals/task-modal/task-modal.component.ts
@@ -62,7 +62,6 @@ export class TaskModalComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    console.log(this.task);
     this.initForm();
   }
 

--- a/src/frontend/Board.Web/src/app/pages/boards-section/boards-list/boards-list.component.scss
+++ b/src/frontend/Board.Web/src/app/pages/boards-section/boards-list/boards-list.component.scss
@@ -143,7 +143,14 @@
     font-size: 1.4rem;
     font-weight: 600;
     color: var(--text-color);
-    flex: 1;
+    flex: 1;    
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.3;
+    max-height: 2.6em;
   }
 
   .board-actions {
@@ -167,11 +174,15 @@
 .board-description {
   color: #7f8c8d;
   margin-bottom: 20px;
-  line-height: 1.5;
+  line-height: 1.5; 
+  word-wrap: break-word;
+  word-break: break-word;  
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;
+  max-height: 3em;
 }
 
 .board-meta {

--- a/src/frontend/Board.Web/src/app/pages/boards-section/boards-list/boards-list.component.ts
+++ b/src/frontend/Board.Web/src/app/pages/boards-section/boards-list/boards-list.component.ts
@@ -3,12 +3,13 @@ import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { MatMenuModule } from '@angular/material/menu';
 import { TranslateModule } from '@ngx-translate/core';
-import { BoardLookupDTO, AddBoardDTO, BoardDetailsDTO, UpdateBoardDTO } from 'src/app/core/models';
+import { BoardLookupDTO, BoardDetailsDTO } from 'src/app/core/models';
 import { BoardApiService } from 'src/app/core/services/api-services';
 import { DialogService } from 'src/app/core/services/other/dialog.service';
-import { Observable, switchMap, tap } from 'rxjs';
+import { Observable, tap } from 'rxjs';
 import { UserService } from 'src/app/core/services/auth/user.service';
 import { UserAccess } from 'src/app/core/models/enums/user-access.enum';
+import { BoardModalResult } from 'src/app/pages/boards-section/boards-list/modals/create-board-modal/create-board-modal.component';
 
 @Component({
   selector: 'app-boards-list',
@@ -53,9 +54,9 @@ export class BoardsListComponent implements OnInit {
   }
 
   onCreateBoard(): void {
-    this.dialogService.openCreateBoardModal().subscribe((boardData) => {
-      if (boardData) {
-        this.boardApiService.addBoard(boardData as AddBoardDTO).pipe(switchMap(()=>this.loadBoards())).subscribe();
+    this.dialogService.openCreateBoardModal().subscribe((result?: BoardModalResult) => {
+      if (result?.success && result?.boards) {
+        this.boards = result.boards;
       }
     });
   }
@@ -66,7 +67,6 @@ export class BoardsListComponent implements OnInit {
         this.boards = this.boards.filter(b => b.id !== boardId);
       },
       error: (err) => {
-        console.error('Error deleting board:', err);
         this.error = 'Failed to delete board';
       }
     });
@@ -82,9 +82,9 @@ export class BoardsListComponent implements OnInit {
 
     this.boardApiService.getBoardById(this.selectedBoard.id).subscribe({
       next: (boardDetails: BoardDetailsDTO) => {
-        this.dialogService.openEditBoardModal(boardDetails).subscribe((updateDto?: UpdateBoardDTO) => {
-          if (updateDto) {
-            this.boardApiService.updateBoard(updateDto).pipe(switchMap(()=>this.loadBoards())).subscribe();
+        this.dialogService.openEditBoardModal(boardDetails).subscribe((result?: BoardModalResult) => {
+          if (result?.success && result?.boards) {
+            this.boards = result.boards;
           }
         });
       }

--- a/src/frontend/Board.Web/src/assets/i18n/en.json
+++ b/src/frontend/Board.Web/src/assets/i18n/en.json
@@ -5,6 +5,16 @@
     "REQUEST_FAILED": "Request failed",
     "ERROR": "Error"
   },
+  "ERRORS": {
+    "VALIDATION_TITLE": "Validation Error",
+    "VALIDATION_FAILED": "Please check the form and correct the errors.",
+    "ERROR_TITLE": "Error",
+    "UNAUTHORIZED_TITLE": "Unauthorized",
+    "FORBIDDEN_TITLE": "Access Denied",
+    "NOT_FOUND_TITLE": "Not Found",
+    "SERVER_ERROR_TITLE": "Server Error",
+    "UNEXPECTED_ERROR": "An unexpected error occurred"
+  },
   "NAV": {
     "BOARD_APP": "BOARD APP",
     "LOG_IN": "Log in",

--- a/src/frontend/Board.Web/src/assets/i18n/ru.json
+++ b/src/frontend/Board.Web/src/assets/i18n/ru.json
@@ -5,6 +5,16 @@
     "REQUEST_FAILED": "Не удалось выполнить запрос",
     "ERROR": "Ошибка"
   },
+  "ERRORS": {
+    "VALIDATION_TITLE": "Ошибка валидации",
+    "VALIDATION_FAILED": "Проверьте форму и исправьте ошибки.",
+    "ERROR_TITLE": "Ошибка",
+    "UNAUTHORIZED_TITLE": "Не авторизован",
+    "FORBIDDEN_TITLE": "Доступ запрещен",
+    "NOT_FOUND_TITLE": "Не найдено",
+    "SERVER_ERROR_TITLE": "Ошибка сервера",
+    "UNEXPECTED_ERROR": "Произошла неожиданная ошибка"
+  },
   "NAV": {
     "BOARD_APP": "BOARD APP",
     "LOG_IN": "Войти",


### PR DESCRIPTION
1. Global HTTP error interception for all API requests.
2. Validation error handling with detailed field-specific messages.
3. Standardized error display using toast notifications.
4. Fixed console error when open create/edit task modal window.
5. Changed the save logic for the board creation/editing modal window. Now, if the board creation/editing process fails, the modal window won't close.